### PR TITLE
ci(docs): add manual dispatch for docs smoke-test

### DIFF
--- a/.github/workflows/docs-smoke-test-on-gh-pages.yml
+++ b/.github/workflows/docs-smoke-test-on-gh-pages.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - gh-pages
+  # Allow manual runs for debugging and validation
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Add workflow_dispatch to docs-smoke-test-on-gh-pages so maintainers can manually run the smoke-test for debugging and validation before relying on gh-pages push events.